### PR TITLE
Update parser based on  latest wiki format

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ extern crate parse_mediawiki_dump;
 fn main() {
     let file = std::fs::File::open("example.xml.bz2").unwrap();
     let file = std::io::BufReader::new(file);
-    let file = bzip2::bufread::BzDecoder::new(file);
+    let file = bzip2::bufread::MultiBzDecoder::new(file);
     let file = std::io::BufReader::new(file);
     for result in parse_mediawiki_dump::parse(file) {
         match result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,6 @@ fn next(parser: &mut Parser<impl BufRead>) -> Result<Option<Page>, Error> {
             .read_event(&mut parser.buffer)?
         {
             Event::Start(event) => {
-                println!("{}", std::str::from_utf8(event.local_name()).unwrap());
                 if event.name() != b"page" {
                     let mut buf = vec![];
                     parser.reader.read_to_end(event.name(),&mut buf)?;

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -4,31 +4,17 @@
 
 extern crate parse_mediawiki_dump;
 
-const DUMP: &str = concat!(
-    r#"<mediawiki xmlns="http://www.mediawiki.org/xml/export-0.10/">"#,
-    "<page>",
-    "<ns>0</ns>",
-    "<title>alpha</title>",
-    "<revision>",
-    "<format>beta</format>",
-    "<model>gamma</model>",
-    "<text>delta</text>",
-    "</revision>",
-    "</page>",
-    "<page>",
-    "<ns>42</ns>",
-    "<title>epsilon</title>",
-    "<revision>",
-    "<text>zeta</text>",
-    "</revision>",
-    "</page>",
-    "</mediawiki>"
-);
+use std::fs::File;
+use std::io::BufReader;
+
+const DUMP_OCT: &str = "./tests/test.xml";
 
 #[test]
 fn main() {
+    let  file = File::open(DUMP_OCT).unwrap();
+    let reader = BufReader::new(file);
     let mut parser =
-        parse_mediawiki_dump::parse(std::io::BufReader::new(std::io::Cursor::new(DUMP)));
+        parse_mediawiki_dump::parse(reader);
     assert!(match parser.next() {
         Some(Ok(parse_mediawiki_dump::Page {
             format: Some(format),
@@ -36,18 +22,12 @@ fn main() {
             namespace: 0,
             text,
             title,
-        })) => format == "beta" && model == "gamma" && text == "delta" && title == "alpha",
-        _ => false,
-    });
-    assert!(match parser.next() {
-        Some(Ok(parse_mediawiki_dump::Page {
-            format: None,
-            model: None,
-            namespace: 42,
-            text,
-            title,
-        })) => text == "zeta" && title == "epsilon",
+        })) => format == "text/x-wiki" && text == "#REDIRECT [[Computer accessibility]]
+{{R from move}}
+{{R from CamelCase}}
+{{R unprintworthy}}" && model == "wikitext" && title == "AccessibleComputing",
         _ => false,
     });
     assert!(parser.next().is_none());
 }
+

--- a/tests/test.xml
+++ b/tests/test.xml
@@ -1,0 +1,71 @@
+<mediawiki xmlns="http://www.mediawiki.org/xml/export-0.10/" xmlns:xsi="http://www.w3.org/2001
+/XMLSchema-instance" xsi:schemaLocation="http://www.mediawiki.org/xml/export-0.10/ http://www.
+mediawiki.org/xml/export-0.10.xsd" version="0.10" xml:lang="en">
+    <siteinfo>
+        <sitename>Wikipedia</sitename>
+        <dbname>enwiki</dbname>
+        <base>https://en.wikipedia.org/wiki/Main_Page</base>
+        <generator>MediaWiki 1.36.0-wmf.10</generator>
+        <case>first-letter</case>
+        <namespaces>
+            <namespace key="-2" case="first-letter">Media</namespace>
+            <namespace key="-1" case="first-letter">Special</namespace>
+            <namespace key="0" case="first-letter" />
+            <namespace key="1" case="first-letter">Talk</namespace>
+            <namespace key="2" case="first-letter">User</namespace>
+            <namespace key="3" case="first-letter">User talk</namespace>
+            <namespace key="4" case="first-letter">Wikipedia</namespace>
+            <namespace key="5" case="first-letter">Wikipedia talk</namespace>
+            <namespace key="6" case="first-letter">File</namespace>
+            <namespace key="7" case="first-letter">File talk</namespace>
+            <namespace key="8" case="first-letter">MediaWiki</namespace>
+            <namespace key="9" case="first-letter">MediaWiki talk</namespace>
+            <namespace key="10" case="first-letter">Template</namespace>
+            <namespace key="11" case="first-letter">Template talk</namespace>
+            <namespace key="12" case="first-letter">Help</namespace>
+            <namespace key="13" case="first-letter">Help talk</namespace>
+            <namespace key="14" case="first-letter">Category</namespace>
+            <namespace key="15" case="first-letter">Category talk</namespace>
+            <namespace key="100" case="first-letter">Portal</namespace>
+            <namespace key="101" case="first-letter">Portal talk</namespace>
+            <namespace key="108" case="first-letter">Book</namespace>
+            <namespace key="109" case="first-letter">Book talk</namespace>
+            <namespace key="118" case="first-letter">Draft</namespace>
+            <namespace key="119" case="first-letter">Draft talk</namespace>
+            <namespace key="119" case="first-letter">Draft talk</namespace>
+            <namespace key="446" case="first-letter">Education Program</namespace>
+            <namespace key="447" case="first-letter">Education Program talk</namespace>
+            <namespace key="710" case="first-letter">TimedText</namespace>
+            <namespace key="711" case="first-letter">TimedText talk</namespace>
+            <namespace key="828" case="first-letter">Module</namespace>
+            <namespace key="829" case="first-letter">Module talk</namespace>
+            <namespace key="2300" case="first-letter">Gadget</namespace>
+            <namespace key="2301" case="first-letter">Gadget talk</namespace>
+            <namespace key="2302" case="case-sensitive">Gadget definition</namespace>
+            <namespace key="2303" case="case-sensitive">Gadget definition talk</namespace>
+        </namespaces>
+    </siteinfo>
+    <page>
+        <title>AccessibleComputing</title>
+        <ns>0</ns>
+        <id>10</id>
+        <redirect title="Computer accessibility" />
+        <revision>
+            <id>854851586</id>
+            <parentid>834079434</parentid>
+            <timestamp>2018-08-14T06:47:24Z</timestamp>
+            <contributor>
+                <username>Godsy</username>
+                <id>23257138</id>
+            </contributor>
+            <comment>remove from category for seeking instructions on rcats</comment>
+            <model>wikitext</model>
+            <format>text/x-wiki</format>
+            <text bytes="94" xml:space="preserve">#REDIRECT [[Computer accessibility]]
+{{R from move}}
+{{R from CamelCase}}
+{{R unprintworthy}}</text>
+            <sha1>42l0cvblwtb4nnupxm6wo000d27t6kf</sha1>
+        </revision>
+    </page>
+</mediawiki>


### PR DESCRIPTION
Thanks for this package!

I ran into trouble using this on the latest wiki dumps for April and  October.  This PR updates the following

- The `match_namespace` function matches the page's namespace against the xml's namespace.  This is guaranteed to fail on recent wikidumps.
- The Readme suggests a BzDecoder for reading the compressed dumps, wikidumps require MultiBzDecoder
- The code did not exit on the EOF event, it now returns OK(None)
- Unit test updated to reflect the head of the 20201001 dump.
